### PR TITLE
keyboard: remove explicit JavaScript version

### DIFF
--- a/keyboard.html
+++ b/keyboard.html
@@ -17,7 +17,7 @@
     <div id="press" class="result"></div>
     <div id="up" class="result"></div>
   </div>
-  <script type="application/javascript;version=1.7">
+  <script type="application/javascript">
    let input = document.getElementById("keyInput"),
        props = ["key", "charCode", "which", "code", "keyCode", "location", "altKey", "ctrlKey", "metaKey", "shiftKey"],
        modifierKeys = ["Alt", "AltGraph", "CapsLock", "Control", "Fn", "FnLock", "Hyper", "Meta", "NumLock", "OS", "ScrollLock", "Shift", "Super", "Symbol", "SymbolLock"],


### PR DESCRIPTION
The page was no longer working in Firefox Nightly. Probably because
specifying an explicit JS version has been deprecated ([bug 1428745](https://bugzilla.mozilla.org/show_bug.cgi?id=1428745))
Yet it would be great to have it working again to test the uplifted
keyboard fingerprinting protection.